### PR TITLE
Trim the output of the commands to support ROS systems

### DIFF
--- a/WireGuardCommand/Pages/Project/ProjectView.razor.cs
+++ b/WireGuardCommand/Pages/Project/ProjectView.razor.cs
@@ -226,7 +226,7 @@ public partial class ProjectView
                     }
                 }
 
-                await File.WriteAllTextAsync(filePath, commands);
+                await File.WriteAllTextAsync(filePath, commands.Trim());
             }
 
             if (Cache.CurrentProject.ProjectData.IsZippedOutput)


### PR DESCRIPTION
RouterOS cannot import commands with whitespace / line-endings at the end.
Trimming the output file fixes this.