### PR TITLE
Separate tests from build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build & Test
+name: Build
 
 on: [push, workflow_dispatch]
 
@@ -14,7 +14,4 @@ jobs:
         
       - name: Compile
         run: dotnet build
-        
-      - name: Run Tests
-        run: dotnet test
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Test
+
+on: [push, workflow_dispatch]
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Prerequisites
+        run: sudo apt install dotnet-sdk-8.0 -y
+      
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        
+      - name: Compile
+        run: dotnet test

--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ A tool designed for generating road-warrior style WireGuard configuration files.
 
 This project is not assocated with the WireGuard trademark in any way.
 
+## Workflows
+
+| Workflow | Status |
+| - | - |
+| Build | ![Build Status](https://github.com/lewpar/WireGuardCommand/actions/workflows/build.yml/badge.svg) |
+| Test | ![Test Status](https://github.com/lewpar/WireGuardCommand/actions/workflows/test.yml/badge.svg) |
+
 ## Build
 The project is built on top of [Electron.NET](https://github.com/ElectronNET/Electron.NET) so you will need the [ElectronNET.API](https://www.nuget.org/packages/ElectronNET.API/) installed.
 


### PR DESCRIPTION
The tests should be run in their own action to quickly view which actions have failed.