### PR TITLE
Add support for server allowed IPs to evaluator.

### DIFF
--- a/WireGuardCommand/Components/Dialogs/EvalVariables.razor
+++ b/WireGuardCommand/Components/Dialogs/EvalVariables.razor
@@ -5,12 +5,12 @@
     <b>Generic</b>
     <ul>
         <li>{interface.name} - The name of the interface.</li>
-        <li>{allowed.ip} - The allowed IPs that can connect.</li>
+        <li>{allowed.ip} - The allowed IP that can connect to the peers.</li>
     </ul>
     <b>Server</b>
     <ul>
         <li>{server.endpoint} - The server endpoint.</li>
-        <li>{server.address} - The address for the server.</li>
+        <li>{server.address} - The address for the se   rver.</li>
         <li>{server.port} - The port the server is listening on.</li>
         <li>{server.privatekey} - The servers private key.</li>
         <li>{server.publickey} - The servers public key.</li>
@@ -18,6 +18,7 @@
     <b>Peer</b>
     <ul>
         <li>{peer.id} - The peer id.</li>
+        <li>{peer.allowed.ip} - The allowed IP that can connect to the server.</li>
         <li>{peer.address} - The address for the peer.</li>
         <li>{peer.port} - The port the peer is listening on.</li>
         <li>{peer.privatekey} - The peers private key.</li>

--- a/WireGuardCommand/Pages/Project/ProjectView.razor.cs
+++ b/WireGuardCommand/Pages/Project/ProjectView.razor.cs
@@ -311,6 +311,7 @@ public partial class ProjectView
             }
 
             content = content.Replace("{peer.id}", peerId.ToString());
+            content = content.Replace("{peer.allowed.ip}", $"{peer.Address}/32");
 
             content = content.Replace("{peer.address}", peer.Address.ToString());
             content = content.Replace("{peer.port}", peer.ListenPort.ToString());

--- a/WireGuardCommand/WireGuardCommand.csproj
+++ b/WireGuardCommand/WireGuardCommand.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="wwwroot\lib\highlightjs\es\**" />


### PR DESCRIPTION
The evaluator was missing the access to the allows IPs for the server peers.