### PR TITLE
Added subnet CIDR to evaluator.

### DIFF
--- a/WireGuardCommand/Components/Dialogs/EvalVariables.razor
+++ b/WireGuardCommand/Components/Dialogs/EvalVariables.razor
@@ -6,11 +6,12 @@
     <ul>
         <li>{interface.name} - The name of the interface.</li>
         <li>{allowed.ip} - The allowed IP that can connect to the peers.</li>
+        <li>{subnet.cidr} - The CIDR for the subnet.</li>
     </ul>
     <b>Server</b>
     <ul>
         <li>{server.endpoint} - The server endpoint.</li>
-        <li>{server.address} - The address for the se   rver.</li>
+        <li>{server.address} - The address for the server.</li>
         <li>{server.port} - The port the server is listening on.</li>
         <li>{server.privatekey} - The servers private key.</li>
         <li>{server.publickey} - The servers public key.</li>

--- a/WireGuardCommand/Pages/Project/ProjectView.razor.cs
+++ b/WireGuardCommand/Pages/Project/ProjectView.razor.cs
@@ -292,6 +292,7 @@ public partial class ProjectView
         // Generic vars
         content = content.Replace("{interface.name}", data.Interface);
         content = content.Replace("{allowed.ip}", data.AllowedIPs);
+        content = content.Replace("{subnet.cidr}", server.Subnet.Cidr.ToString());
 
         // Server vars
         content = content.Replace("{server.endpoint}", data.Endpoint);
@@ -311,7 +312,7 @@ public partial class ProjectView
             }
 
             content = content.Replace("{peer.id}", peerId.ToString());
-            content = content.Replace("{peer.allowed.ip}", $"{peer.Address}/32");
+            content = content.Replace("{peer.allowed.ip}", $"{peer.Address}");
 
             content = content.Replace("{peer.address}", peer.Address.ToString());
             content = content.Replace("{peer.port}", peer.ListenPort.ToString());

--- a/WireGuardCommand/WireGuardCommand.csproj
+++ b/WireGuardCommand/WireGuardCommand.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>2.1.2</Version>
+    <Version>2.1.3</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="wwwroot\lib\highlightjs\es\**" />


### PR DESCRIPTION
There was no way to access the CIDR for the subnet in the case where you wanted to use it in the evaluator.
The hard-coded CIDR on allowed IPs was also removed as it can be added to the evaluator by the user.